### PR TITLE
Fixes - add missing int64 format and fix time format from RFC3339 to ISO8601

### DIFF
--- a/client.go
+++ b/client.go
@@ -35,6 +35,8 @@ func toValue(arg interface{}) (valueizable, error) {
 	case reflect.Int16:
 		fallthrough
 	case reflect.Int32:
+		fallthrough
+	case reflect.Int64:
 		return newInt(v.Int()), nil
 	case reflect.Float32:
 		fallthrough

--- a/result.go
+++ b/result.go
@@ -157,7 +157,7 @@ func parseElement(e *etree.Element) (*Result, error) {
 		}
 		return &Result{resDouble: double, kind: KindDouble}, nil
 	case "dateTime.iso8601":
-		time, err := time.Parse(time.RFC3339, e.Text())
+		time, err := time.Parse(timeFormat, e.Text())
 		if err != nil {
 			return nil, errors.Wrapf(err, "cannot convert '%s' to a date", e.Text())
 		}

--- a/structure.go
+++ b/structure.go
@@ -29,6 +29,8 @@ const enStruct = "struct"
 const enArray = "array"
 const enData = "data"
 
+const timeFormat  = "2006-01-02T15:04:05-0700"
+
 type payload struct {
 	*etree.Document
 }
@@ -100,7 +102,7 @@ func newDouble(data float64) *scalar {
 }
 
 func newDateTime(data time.Time) *scalar {
-	return newScalar(enDateTime, data.UTC().Format(time.RFC3339))
+	return newScalar(enDateTime, data.UTC().Format(timeFormat))
 }
 
 func newBase64(data []byte) *scalar {


### PR DESCRIPTION
Add missing int64 format and fix time format from RFC3339 to ISO8601.